### PR TITLE
fix for e.code return on non-alphanumeric keypress

### DIFF
--- a/feedly_background_tab.js
+++ b/feedly_background_tab.js
@@ -11,17 +11,17 @@
 		'.list-entries .selected a.visitWebsiteButton',
 		'a.visitWebsiteButton',
 		'.entry.selected a.title',
-		'.entry--selected a.entry__title'	 // add feedback		
+		'.entry--selected a.entry__title'	 // add feedback
 	]
 
 	var App = function () {
-		var _triggerCharCode = "KeyH"  // default is 'h'
+		var _triggerCharCode = "h"  // default is 'h'
 		this.init = function () {
 			// if setting another shortcut key,,, change trigger
 			chrome.storage.local.get("shortcut", items => {
 				if (typeof items.shortcut === "undefined") {
 				} else {
-					_triggerCharCode = "Key" + items.shortcut.toUpperCase();
+					_triggerCharCode = items.shortcut;
 					// console.log("change key by setting")
 					// console.log(_triggerCharCode)
 				}
@@ -31,7 +31,7 @@
 		this.keyDownHandler = function (e) {
 			var tag = e.target.tagName.toLowerCase()
 			if (tag != 'input' && tag != 'textarea') {
-				if (e.code == _triggerCharCode) {
+				if (e.key == _triggerCharCode) {
 					var url
 					for (var x in selectors) {			// for Article mode
 						url = document.querySelector(selectors[x])


### PR DESCRIPTION
It looks like Firefox may have changed the return values for keypress codes for non-alphanumeric characters. This was causing my *;* shortcut to not work. `e.code` returns 'Semicolon' instead of 'Key;' when a semicolon is pushed, causing the Key string comparison to fail. This doesn't seem to be unique to a semicolon - a period '.' e.code returns 'Period' instead of 'Key.'. 

Changing the evaluation to use e.key fixes it. If you wanted to, you could instead change the evaluation to:

```javascript
if (e.code == _triggerCharCode || 'Key' + e.key == _triggerCharCode) {
``` 

But that feels a little less clean to me, so I tossed the 'Key' and changed e.code to e.key. 

Thanks for this extension! I find Feedly borderline unusable without it. 